### PR TITLE
Create GitHub Action to spin up Open Interpreter

### DIFF
--- a/.github/workflows/spin-up-open-interpreter.yml
+++ b/.github/workflows/spin-up-open-interpreter.yml
@@ -1,0 +1,50 @@
+name: Spin Up Open Interpreter
+
+on:
+  push:
+    branches: ["main", "development"]
+  pull_request:
+    branches: ["main", "development"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker image
+        run: docker build --tag open-interpreter:latest .
+
+      - name: Run Docker container
+        run: docker run --name open-interpreter -d open-interpreter:latest
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.10
+
+      - name: Create virtual environment
+        run: python -m venv venv
+
+      - name: Activate virtual environment
+        run: source venv/bin/activate
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Spin up Open Interpreter
+        run: |
+          docker exec open-interpreter bash -c "source venv/bin/activate && interpreter"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # To learn more about LMC, visit https://docs.openinterpreter.com/protocols/lmc-messages. #
 ###########################################################################################
 
-FROM python:3.11.8
+FROM python:3.10
 
 # Set environment variables
 # ENV OPENAI_API_KEY ...


### PR DESCRIPTION
Add a GitHub Action to spin up an instance of Open Interpreter using a virtual environment with Python 3.10 within a configured Docker container.

* **Dockerfile**
  - Update the base image to `python:3.10`.

* **.github/workflows/spin-up-open-interpreter.yml**
  - Create a new GitHub Action workflow file.
  - Add steps to build the Docker image.
  - Add steps to create a virtual environment with Python 3.10.
  - Add steps to spin up an instance of Open Interpreter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nate-dryer/open-interpreter?shareId=ebf56bca-3d44-430a-a277-708770309470).